### PR TITLE
Allow SBT to find sbt-scripted, which is not in Maven Central for < 1.x

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -6,11 +6,17 @@ lazy val root = (project in file("."))
     .enablePlugins(ScriptedPlugin)
     .settings(
         crossScalaVersions in ThisBuild := Seq(Scala210, Scala212),
-
+        resolvers += Resolver.typesafeIvyRepo("releases"),
         organization := "$organization$",
 
         name := "$name$",
 
+        scriptedSbt := {
+          scalaBinaryVersion.value match {
+                  case "2.10" => "0.13.7"
+                  case "2.12" => "1.2.7"
+          }
+        },
         libraryDependencies ++= Seq(
             "com.thesamet.scalapb" %% "compilerplugin" % "$scalapb_version$"
         ),


### PR DESCRIPTION
Trying to do `> +publishLocal` on a fresh copy of the generated template results in the error below. Somehow, the scripted-sbt plugin moved from the typesafe bintray but the sbt 0.13.x versions got left behind. This PR addresses that

```
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	::          UNRESOLVED DEPENDENCIES         ::
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 	:: org.scala-sbt#scripted-sbt_2.10;1.2.6: not found
[warn] 	::::::::::::::::::::::::::::::::::::::::::::::
[warn] 
[warn] 	Note: Unresolved dependencies path:
[warn] 		org.scala-sbt:scripted-sbt_2.10:1.2.6 ((sbt.ScriptedPlugin.projectSettings) ScriptedPlugin.scala#L62)
[warn] 		  +- com.tubitv:not-working-plugin_2.10:0.1.0-SNAPSHOT
[error] sbt.librarymanagement.ResolveException: unresolved dependency: org.scala-sbt#scripted-sbt_2.10;1.2.6: not found
[error] 	at sbt.internal.librarymanagement.IvyActions$.resolveAndRetrieve(IvyActions.scala:332)
[error] 	at sbt.internal.librarymanagement.IvyActions$.$anonfun$updateEither$1(IvyActions.scala:208)
[error] 	at sbt.internal.librarymanagement.IvySbt$Module.$anonfun$withModule$1(Ivy.scala:239)
[error] 	at sbt.internal.librarymanagement.IvySbt.$anonfun$withIvy$1(Ivy.scala:204)
[error] 	at sbt.internal.librarymanagement.IvySbt.sbt$internal$librarymanagement$IvySbt$$action$1(Ivy.scala:70)
```