### PR TITLE
Fix inconsistent tab and spaces in protoc-gen-template

### DIFF
--- a/src/main/g8/code-gen/src/main/scala/$package$/compiler/CodeGenerator.scala
+++ b/src/main/g8/code-gen/src/main/scala/$package$/compiler/CodeGenerator.scala
@@ -43,7 +43,7 @@ object CodeGenerator extends CodeGenApp {
             file <- request.filesToGenerate
             message <- file.getMessageTypes().asScala
           } yield new MessagePrinter(message, implicits).result
-	    )
+      )
       case Left(error)   =>
         CodeGenResponse.fail(error)
     }
@@ -86,6 +86,6 @@ class MessagePrinter(message: Descriptor, implicits: DescriptorImplicits) {
       s"package \${message.getFile.scalaPackage.fullName}",
       "",
     ).call(printObject)
-    fp.result
+    fp.result()
   }
 }


### PR DESCRIPTION
Also remove an auto application which is not supported in Scala3.

I noticed these issues when opening the project in Scala3 mode.